### PR TITLE
use Test::Stream if it is loaded, not if it can be loaded

### DIFF
--- a/lib/Test/Exception.pm
+++ b/lib/Test/Exception.pm
@@ -332,7 +332,7 @@ The test description is optional, but recommended.
 
 =cut
 
-my $is_stream = eval { require Test::Stream; require Test::Stream::Event::Ok; 1 };
+my $is_stream = $INC{'Test/Stream.pm'};
 our $LIVES_AND_NAME;
 if ($is_stream) {
     Test::Stream->shared->munge(sub {


### PR DESCRIPTION
Test::Stream may exist and work on a system, but the Test::Builder be
from the older pre-Stream version.  This can happen if Test::More is
downgraded.  If this is the case, loading Test::Stream will work but
trying to use its API to effect Test::Builder won't do anything.

Instead, use the new Test::Stream API if it has already been loaded by
Test::Builder.

Fixes #6
