### PR TITLE
Try to fix RT #81529

### DIFF
--- a/lib/Test/Exception.pm
+++ b/lib/Test/Exception.pm
@@ -216,11 +216,16 @@ sub throws_ok (&$;$) {
     	unless defined $description;
     my $exception = _try_as_caller( $coderef );
     my $regex = $Tester->maybe_regex( $expecting );
-    my $ok = $regex 
-        ? ( $exception =~ m/$regex/ ) 
-        : eval { 
-            $exception->isa( ref $expecting ? ref $expecting : $expecting ) 
-        };
+    my $ok;
+    if ($exception) {
+      $ok = $regex 
+          ? ( $exception =~ m/$regex/ ) 
+          : eval { 
+              $exception->isa( ref $expecting ? ref $expecting : $expecting ) 
+          };
+    } else {
+      $ok = 0;
+    }
     $Tester->ok( $ok, $description );
     unless ( $ok ) {
         $Tester->diag( _exception_as_string( "expecting:", $expecting ) );

--- a/t/throws_ok.t
+++ b/t/throws_ok.t
@@ -2,8 +2,23 @@
 
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::Builder;
+use Test::Harness;
+use Test::Builder::Tester tests => 4;
+use Test::More;
+
 BEGIN { use_ok( 'Test::Exception' ) };
 
 eval { throws_ok {} undef };
 like( $@, '/^throws_ok/', 'cannot pass undef to throws_ok' );
+
+{
+  test_out('not ok 1 - threw Regexp ((?^:Correct output from not throwing in a throws_ok))');
+  test_fail( +1 );
+  my $ok = throws_ok { 1 } qr/Correct output from not throwing in a throws_ok/;
+  test_test(name => 'Correct output from not throwing in a throws_ok', skip_err => 1);
+
+  ok(!$ok, 'Fail if you don\'t throw in a throws_ok');
+}
+
+done_testing;


### PR DESCRIPTION
I've written code to try to fix the case where you call throws_ok, the code doesn't die, and the test passes (RT#81529).

The test in t/Exception.t that doesn't throw ("throws_ok: normal exit matched") is failing due to this code change.

Just thought you'd like to consider this new behaviour, since the original (passing the test) is very confusing.