### PR TITLE
fix erratic indenting

### DIFF
--- a/lib/Test/Exception.pm
+++ b/lib/Test/Exception.pm
@@ -214,11 +214,11 @@ form part of the string that throws_ok regular expressions match against.
 sub throws_ok (&$;$) {
     my ( $coderef, $expecting, $description ) = @_;
     unless (defined $expecting) {
-      require Carp;
-      Carp::croak( "throws_ok: must pass exception class/object or regex" ); 
+        require Carp;
+        Carp::croak( "throws_ok: must pass exception class/object or regex" ); 
     }
     $description = _exception_as_string( "threw", $expecting )
-    	unless defined $description;
+        unless defined $description;
     my $exception = _try_as_caller( $coderef );
     my $regex = $Tester->maybe_regex( $expecting );
     my $ok = $regex 
@@ -301,7 +301,7 @@ sub lives_ok (&;$) {
     my ( $coderef, $description ) = @_;
     my $exception = _try_as_caller( $coderef );
     my $ok = $Tester->ok( ! _is_exception( $exception ), $description );
-	$Tester->diag( _exception_as_string( "died:", $exception ) ) unless $ok;
+    $Tester->diag( _exception_as_string( "died:", $exception ) ) unless $ok;
     $@ = $exception;
     return $ok;
 }


### PR DESCRIPTION
I went to look for any obvious problems to sort out for the CPAN PRC, and strangely enough there was Vim blaring at me about a single tab file among a sea of spaces.  I fixed it.

Also another one.

And two places where the indenting was 2-sp instead of 4-sp.

This is a sad commit, but it is not valueless, I think. 😊