### PR TITLE
Support Test::Deep expectations

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -53,6 +53,7 @@ my %WriteMakefileArgs = (
       test => {
         requires => {
           'Test::More'              => '0.7',
+          'Test::Deep'              => '0',
           'overload'                => '0',
         },
       },

--- a/t/throws-ok-with-test-deep.t
+++ b/t/throws-ok-with-test-deep.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Test::Deep;
+
+BEGIN { use_ok( 'Test::Exception' ) };
+
+throws_ok
+    { die Local::Error->new( code => 404, message => 'Not Found' ) }
+    all(
+        obj_isa( 'Local::Error' ),
+        methods(
+            code => 404,
+            message => re( qr/found/i ),
+        ),
+    ),
+    'should recognize Test::Deep::Cmp expectation'
+    ;
+
+package
+    Local::Error;
+
+sub new {
+    my ( $class, %params ) = @_;
+
+    bless \%params, $class;
+}
+
+sub code {
+    $_[0]->{code};
+}
+
+sub message {
+    $_[0]->{message};
+}
+


### PR DESCRIPTION
Test::Deep provides nice support for writing complex expectations
that comes handy especially when system under test throws objects

```
    throws_ok
        { code that should throw exception }
        all (
            obj_isa ('Expected::Exception::Instance'),
            methods (
                errcode => 400,
                errstr  => re (qr/foo/),
            )
        ),
        'description'
        ;
```

Test::Deep is not dependency of Test::Exception, it is only recognized
and used then assuming library is already loaded.